### PR TITLE
Optimize error message printing

### DIFF
--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -21,7 +21,7 @@
 
 		namespace cjdb::contracts_detail {
 			struct print_error_fn {
-				template<std::size_t N>
+				template<std::size_t N> // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 				CJDB_FORCE_INLINE void operator()(char const(&message)[N]) const noexcept
 				{
 					std::fwrite(message, sizeof(char), N - 1, stderr);
@@ -34,7 +34,7 @@
 
 		namespace cjdb::contracts_detail {
 			struct print_error_fn {
-				template<std::size_t N>
+				template<std::size_t N> // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 				CJDB_FORCE_INLINE void operator()(char const(&message)[N]) const noexcept
 				try {
 					std::cerr.write(message, static_cast<std::streamsize>(N) - 1);
@@ -66,8 +66,8 @@ namespace cjdb::contracts_detail {
 	struct contract_impl_fn {
 		template<std::size_t N1, std::size_t N2>
 		constexpr void operator()(bool const result,
-		                          char const(&message)[N1],
-		                          char const(&function)[N2]) const noexcept
+		                          char const(&message)[N1], // NOLINT(modernize-avoid-c-arrays)
+		                          char const(&function)[N2]) const noexcept // NOLINT(modernize-avoid-c-arrays)
 		{
 			if (not result) [[unlikely]] {
 				if (not std::is_constant_evaluated()) {

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -71,7 +71,7 @@ namespace cjdb::contracts_detail {
 		{
 			if (not result) [[unlikely]] {
 				if (not std::is_constant_evaluated()) {
-					if constexpr (is_debug) { // NOLINT(bugprone-suspicious-semicolon)
+					if constexpr (is_debug) { // NOLINT
 						constexpr auto& suffix = "`\n";
 						constexpr auto message_size = N1 - 1;
 						constexpr auto function_size = N2 - 1;

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -74,7 +74,7 @@ namespace cjdb::contracts_detail {
 					if constexpr (is_debug) {
 						constexpr auto& suffix = "`\n";
 						constexpr auto message_size = N1 - 1, function_size = N2 - 1;
-						char full_message[message_size + function_size + sizeof suffix];
+						char full_message[message_size + function_size + sizeof suffix]{};
 						auto p = full_message;
 						std::memcpy(p, message, message_size);
 						std::memcpy(p += message_size, function, function_size);

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -71,7 +71,7 @@ namespace cjdb::contracts_detail {
 		{
 			if (not result) [[unlikely]] {
 				if (not std::is_constant_evaluated()) {
-					if constexpr (is_debug) {
+					if constexpr (is_debug) { // NOLINT(bugprone-suspicious-semicolon)
 						constexpr auto& suffix = "`\n";
 						constexpr auto message_size = N1 - 1;
 						constexpr auto function_size = N2 - 1;

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -34,10 +34,10 @@
 
 		namespace cjdb::contracts_detail {
 			struct print_error_fn {
-				template<std::streamsize N>
+				template<std::size_t N>
 				CJDB_FORCE_INLINE void operator()(char const(&message)[N]) const noexcept
 				try {
-					std::cerr.write(message, N - 1);
+					std::cerr.write(message, static_cast<std::streamsize>(N) - 1);
 				} catch(...) {}
 			};
 			inline constexpr auto print_error = print_error_fn{};
@@ -73,7 +73,9 @@ namespace cjdb::contracts_detail {
 				if (not std::is_constant_evaluated()) {
 					if constexpr (is_debug) {
 						constexpr auto& suffix = "`\n";
-						constexpr auto message_size = N1 - 1, function_size = N2 - 1;
+						constexpr auto message_size = N1 - 1;
+						constexpr auto function_size = N2 - 1;
+						// NOLINTNEXTLINE(modernize-avoid-c-arrays)
 						char full_message[message_size + function_size + sizeof suffix]{};
 						auto p = full_message;
 						std::memcpy(p, message, message_size);


### PR DESCRIPTION
And allow the error message printing function to be configured by the user. In particular, stdio functions may not be safe to call if the user has called std::ios_base::sync_with_stdio(false) .