### PR TITLE
Further optimized error printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ contracts are always checked at compile-time. If the contract's predicate isn't 
 program won't compile. This is a huge advantage over using `<cassert>` or the GSL's `Expects` and
 `Ensures` macros.
 
-When optimisations are diabled and `NDEBUG` is not defined as a macro, the contract will check your
-predicate at run-time. If the predicate fails, then a diagnostic will be emit, and the program will
+When optimisations are disabled and `NDEBUG` is not defined as a macro, the contract will check your
+predicate at run-time. If the predicate fails, then a diagnostic will be emitted, and the program will
 crash.
 
 When optimisations are enabled, and `NDEBUG` remains undefined, the program will emit a diagnostic
@@ -196,7 +196,11 @@ generation than when the contract isn't used. [See for yourself][__builtin_unrea
 </table>
 
 *Rudimentary testing has identified that neither GCC nor Clang perform optimisations <em>before</em>
-the contract.
+the contract.*
+
+### Configuring diagnostics
+
+By default, diagnostic messages are printed to `stderr` by `std::fwrite`. If `CJDB_USE_IOSTREAM` is defined as a macro, messages are printed with `std::cerr.write` instead. If `CJDB_SKIP_STDIO` is defined as a macro, there is no dependency on either `cstdio` or `iostream` and printing diagnostic messages is a no-op. If you would like to customize how diagnostics are printed, you may set the function pointer `cjdb::print_error` to any function or lambda with the signature `void(std::string_view)`.
 
 ### Assertions
 

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -34,20 +34,17 @@
 namespace cjdb {
 	using print_error_fn = void(std::string_view);
 	inline print_error_fn *print_error
-#ifndef CJDB_SKIP_STDIO
 	= [](std::string_view message) {
 #ifdef CJDB_USE_IOSTREAM
 		std::cerr.write(message.data(), static_cast<std::streamsize>(message.size()));
-#else
+#elif !defined(CJDB_SKIP_STDIO)
 		if (auto const len = message.size();
 			std::fwrite(message.data(), sizeof(char), len, stderr) < len) [[unlikely]]
 		{
 			throw std::system_error{errno, std::system_category()};
 		}
 #endif // CJDB_USE_IOSTREAM
-	}
-#endif // !CJDB_SKIP_STDIO
-	;
+	};
 
 namespace contracts_detail {
 	#ifdef NDEBUG

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -67,7 +67,7 @@ namespace contracts_detail {
 						constexpr auto& suffix = "`\r\n";
 	#else
 						constexpr auto& suffix = "`\n";
-	#endif
+	#endif // _WIN32
 						::cjdb::print_error(message);
 						::cjdb::print_error(function);
 						::cjdb::print_error(suffix);

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -75,7 +75,7 @@ namespace contracts_detail {
 						auto p = full_message;
 						std::memcpy(p, message, message_size);
 						std::memcpy(p += message_size, function, function_size);
-						std::memcpy(p += function_size, suffix, sizeof suffix);
+						std::memcpy(p += function_size, suffix, sizeof suffix - 1);
 						::cjdb::print_error(full_message);
 					}
 				}

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -35,8 +35,7 @@
 			struct print_error_fn {
 				CJDB_FORCE_INLINE void operator()(std::string_view const message) const noexcept
 				try {
-					std::cerr.write(message.data(),
-					                static_cast<std::streamsize>(message.size()));
+					std::cerr << message;
 				} catch(...) {}
 			};
 			inline constexpr auto print_error = print_error_fn{};

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -96,7 +96,7 @@ namespace contracts_detail {
 		}
 	};
 	inline constexpr auto matches_bool = matches_bool_fn{};
-} // namespace cjdb::contracts_detail
+} // namespace contracts_detail
 } // namespace cjdb
 
 #define CJDB_CONTRACT_IMPL(CJDB_KIND, ...) \

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -32,7 +32,8 @@
 #endif // _MSC_VER
 
 namespace cjdb {
-	void(*print_error)(std::string_view)
+	using print_error_fn = void(std::string_view);
+	inline print_error_fn *print_error
 #ifndef CJDB_SKIP_STDIO
 	= [](std::string_view message) {
 #ifdef CJDB_USE_IOSTREAM

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -33,7 +33,7 @@
 
 namespace cjdb {
 	using print_error_fn = void(std::string_view);
-	inline print_error_fn *print_error = [](std::string_view message) {
+	inline print_error_fn* print_error = [](std::string_view message) {
 #ifdef CJDB_USE_IOSTREAM
 		std::cerr.write(message.data(), static_cast<std::streamsize>(message.size()));
 #elif !defined(CJDB_SKIP_STDIO)
@@ -60,11 +60,11 @@ namespace contracts_detail {
 			if (not result) {
 				if (not std::is_constant_evaluated()) {
 					if constexpr (is_debug) {
-	#ifdef _WIN32
+					#ifdef _WIN32
 						constexpr auto& suffix = "`\r\n";
-	#else
+					#else
 						constexpr auto& suffix = "`\n";
-	#endif // _WIN32
+					#endif // _WIN32
 						::cjdb::print_error(message);
 						::cjdb::print_error(function);
 						::cjdb::print_error(suffix);

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -27,7 +27,7 @@
 			CJDB_FORCE_INLINE void operator()(std::string_view const message) const noexcept
 	#ifdef CJDB_USE_IOSTREAM
 			try {
-				std::clog << message;
+				std::clog.write(message.data(), static_cast<std::streamsize>(message.size()));
 			} catch(...) {}
 	#else
 			{

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -21,7 +21,7 @@
 
 		namespace cjdb::contracts_detail {
 			struct print_error_fn {
-				CJDB_FORCE_INLINE void operator()(std::string_view message) const noexcept
+				CJDB_FORCE_INLINE void operator()(std::string_view const message) const noexcept
 				{
 					std::fwrite(message.data(), sizeof(char), message.size(), stderr);
 				}
@@ -33,7 +33,7 @@
 
 		namespace cjdb::contracts_detail {
 			struct print_error_fn {
-				CJDB_FORCE_INLINE void operator()(std::string_view message) const noexcept
+				CJDB_FORCE_INLINE void operator()(std::string_view const message) const noexcept
 				try {
 					std::cerr.write(message.data(),
 					                static_cast<std::streamsize>(message.size()));

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -33,8 +33,7 @@
 
 namespace cjdb {
 	using print_error_fn = void(std::string_view);
-	inline print_error_fn *print_error
-	= [](std::string_view message) {
+	inline print_error_fn *print_error = [](std::string_view message) {
 #ifdef CJDB_USE_IOSTREAM
 		std::cerr.write(message.data(), static_cast<std::streamsize>(message.size()));
 #elif !defined(CJDB_SKIP_STDIO)

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -16,31 +16,27 @@
 #endif // _MSC_VER
 
 #ifndef CJDB_PRINT_ERROR
-	#ifdef CJDB_USE_STDIO
-		#include <cstdio>
-
-		namespace cjdb::contracts_detail {
-			struct print_error_fn {
-				CJDB_FORCE_INLINE void operator()(std::string_view const message) const noexcept
-				{
-					std::fwrite(message.data(), sizeof(char), message.size(), stderr);
-				}
-			};
-			inline constexpr auto print_error = print_error_fn{};
-		} // namespace cjdb::contracts_detail
-	#else
+	#ifdef CJDB_USE_IOSTREAM
 		#include <iostream>
+	#else
+		#include <cstdio>
+	#endif // CJDB_USE_IOSTREAM
 
-		namespace cjdb::contracts_detail {
-			struct print_error_fn {
-				CJDB_FORCE_INLINE void operator()(std::string_view const message) const noexcept
-				try {
-					std::cerr << message;
-				} catch(...) {}
-			};
-			inline constexpr auto print_error = print_error_fn{};
-		} // namespace cjdb::contracts_detail
-	#endif // CJDB_USE_STDIO
+	namespace cjdb::contracts_detail {
+		struct print_error_fn {
+			CJDB_FORCE_INLINE void operator()(std::string_view const message) const noexcept
+	#ifdef CJDB_USE_IOSTREAM
+			try {
+				std::clog << message;
+			} catch(...) {}
+	#else
+			{
+				std::fwrite(message.data(), sizeof(char), message.size(), stderr);
+			}
+	#endif // CJDB_USE_IOSTREAM
+		};
+		inline constexpr auto print_error = print_error_fn{};
+	} // namespace cjdb::contracts_detail
 	#define CJDB_PRINT_ERROR(MESSAGE) ::cjdb::contracts_detail::print_error(MESSAGE)
 #endif // CJDB_PRINT_ERROR
 

--- a/include/cjdb/contracts.hpp
+++ b/include/cjdb/contracts.hpp
@@ -60,11 +60,11 @@ namespace contracts_detail {
 			if (not result) {
 				if (not std::is_constant_evaluated()) {
 					if constexpr (is_debug) {
-	#ifdef _WIN32
+					#ifdef _WIN32
 						constexpr auto& suffix = "`\r\n";
-	#else
+					#else
 						constexpr auto& suffix = "`\n";
-	#endif // _WIN32
+					#endif // _WIN32
 						::cjdb::print_error(message);
 						::cjdb::print_error(function);
 						::cjdb::print_error(suffix);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,15 +3,22 @@
 #
 function(build_contract filename)
 	set(target "${filename}")
+	set(target_ios "${filename}_ios")
 	add_executable("${target}" "${filename}.cpp")
+	add_executable("${target_ios}" "${filename}.cpp")
 	if(MSVC)
 		target_compile_options("${target}" PRIVATE "/permissive-")
+		target_compile_options("${target_ios}" PRIVATE "/permissive-" "/DCJDB_USE_IOSTREAM")
+	else()
+		target_compile_options("${target_ios}" PRIVATE "-DCJDB_USE_IOSTREAM")
 	endif()
 	target_include_directories("${target}" PRIVATE "${CMAKE_SOURCE_DIR}/include")
+	target_include_directories("${target_ios}" PRIVATE "${CMAKE_SOURCE_DIR}/include")
 endfunction()
 
 build_contract(pass)
 add_test(test.pass pass)
+add_test(test.pass_ios pass_ios)
 
 function(test_contract target expected_output)
 	set(args "${CMAKE_SOURCE_DIR}/test/check-failure.py"
@@ -21,6 +28,10 @@ function(test_contract target expected_output)
 		list(APPEND args "--debug=True")
 	endif()
 	add_test(NAME "test.${target}"
+	         COMMAND python3 ${args}
+	         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+	list(TRANSFORM args APPEND "_ios" AT 1)
+	add_test(NAME "test.${target}_ios"
 	         COMMAND python3 ${args}
 	         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 endfunction()


### PR DESCRIPTION
Extends #11 by taking advantage of compile-time information to generate a single error message string (instead of 3) before printing.